### PR TITLE
🔧 ▸ Fixing Bar Prefabs (PB_Bar, PB_HealthBar, PB_NanomachineBar)

### DIFF
--- a/GameFiles/Geometrical Survivor/Assets/Scenes/DevScene.unity
+++ b/GameFiles/Geometrical Survivor/Assets/Scenes/DevScene.unity
@@ -800,10 +800,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1777185436}
     m_Modifications:
-    - target: {fileID: 4448295082667868587, guid: bead6f94f11735c43a097d2f9aeef049, type: 3}
-      propertyPath: m_text
-      value: Value / MaxValue
-      objectReference: {fileID: 0}
     - target: {fileID: 6791359486919853213, guid: bead6f94f11735c43a097d2f9aeef049, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5

--- a/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/PB_Bar.prefab
+++ b/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/PB_Bar.prefab
@@ -163,22 +163,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aea1633dd95d9f4eb1bc38ea80bec8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _backgroundImage: {fileID: 3033292940252801833}
-  _fileBarBackgroundImage: {fileID: 3321401469372258539}
-  _fileBarImage: {fileID: 6253731266286605247}
-  _barIconBackgroundImage: {fileID: 8427336673111203730}
-  _barIconImage: {fileID: 6832791391708791000}
   _fileBarNumbers: {fileID: 1687658848258450395}
+  _fileBarImage: {fileID: 6253731266286605247}
+  _fileBarBackgroundImage: {fileID: 3321401469372258539}
+  _backgroundImage: {fileID: 3033292940252801833}
+  _barIconImage: {fileID: 6832791391708791000}
+  _barIconBackgroundImage: {fileID: 8427336673111203730}
   _barType: 0
   _barComponentValues:
-    _BackgroundColor: {r: 0.65, g: 0.65, b: 0.65, a: 1}
-    _FileBarBackgroundColor: {r: 0.35, g: 0.35, b: 0.35, a: 1}
     _FileBarColor: {r: 0.85, g: 0.85, b: 0.85, a: 1}
+    _FileBarBackgroundColor: {r: 0.35, g: 0.35, b: 0.35, a: 1}
+    _BackgroundColor: {r: 0.65, g: 0.65, b: 0.65, a: 1}
     _BarIconSprite: {fileID: 0}
     _BackgroundBarIconSprite: {fileID: 0}
-    _BackgroundSprite: {fileID: 0}
+    _FileBarSprite: {fileID: 21300000, guid: dc2e8a07e143634489f2d04d940733bb, type: 3}
     _FileBarBackgroundSprite: {fileID: 0}
-    _FileBarSprite: {fileID: 0}
+    _BackgroundSprite: {fileID: 0}
 --- !u!1 &5707362221268479456
 GameObject:
   m_ObjectHideFlags: 0
@@ -453,7 +453,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: dc2e8a07e143634489f2d04d940733bb, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/Prefabs/PB_HealthBar Variant.prefab
+++ b/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/Prefabs/PB_HealthBar Variant.prefab
@@ -13,6 +13,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 8806c5ac0009cb24daf1907480d5d648, type: 3}
     - target: {fileID: 2749036783958448204, guid: 665084055c01ce848bf4129155b1f767, type: 3}
+      propertyPath: _barComponentValues._FileBarSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: dc2e8a07e143634489f2d04d940733bb, type: 3}
+    - target: {fileID: 2749036783958448204, guid: 665084055c01ce848bf4129155b1f767, type: 3}
       propertyPath: _barComponentValues._FileBarColor.b
       value: 0.1837451
       objectReference: {fileID: 0}
@@ -28,6 +32,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: PB_HealthBar Variant
       objectReference: {fileID: 0}
+    - target: {fileID: 6253731266286605247, guid: 665084055c01ce848bf4129155b1f767, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: dc2e8a07e143634489f2d04d940733bb, type: 3}
     - target: {fileID: 6253731266286605247, guid: 665084055c01ce848bf4129155b1f767, type: 3}
       propertyPath: m_Color.b
       value: 0.1837451

--- a/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/Prefabs/PB_NanomachineBar Variant.prefab
+++ b/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/Prefabs/PB_NanomachineBar Variant.prefab
@@ -29,6 +29,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 7e03437b04af4224a9e1024983fb7497, type: 3}
     - target: {fileID: 2749036783958448204, guid: 665084055c01ce848bf4129155b1f767, type: 3}
+      propertyPath: _barComponentValues._FileBarSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: dc2e8a07e143634489f2d04d940733bb, type: 3}
+    - target: {fileID: 2749036783958448204, guid: 665084055c01ce848bf4129155b1f767, type: 3}
       propertyPath: _barComponentValues._FileBarColor.b
       value: 0.28953207
       objectReference: {fileID: 0}
@@ -44,6 +48,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: PB_NanomachineBar Variant
       objectReference: {fileID: 0}
+    - target: {fileID: 6253731266286605247, guid: 665084055c01ce848bf4129155b1f767, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: dc2e8a07e143634489f2d04d940733bb, type: 3}
     - target: {fileID: 6253731266286605247, guid: 665084055c01ce848bf4129155b1f767, type: 3}
       propertyPath: m_Color.b
       value: 0.28953207

--- a/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/S_Bar.cs
+++ b/GameFiles/Geometrical Survivor/Assets/UIs/HUD/Bars/S_Bar.cs
@@ -75,6 +75,8 @@ public class S_Bar : MonoBehaviour
         if (!S_VariablesChecker.AreVariablesCorrectlySetted(gameObject.name, null,
             (_fileBarNumbers, nameof(_fileBarNumbers)),
 
+            (_barComponentValues._FileBarSprite, nameof(_barComponentValues._FileBarSprite)),
+
             (_fileBarImage, nameof(_fileBarImage)),
             (_fileBarBackgroundImage, nameof(_fileBarBackgroundImage)),
             (_backgroundImage, nameof(_backgroundImage)),


### PR DESCRIPTION
The reason of this bug is they didn't have a sprite set (which made the bar progress not visibly updated)